### PR TITLE
Fixed number parsing exceptions

### DIFF
--- a/Orabot/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/BaseNumberParsingMessageHandler.cs
+++ b/Orabot/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/BaseNumberParsingMessageHandler.cs
@@ -32,8 +32,7 @@ namespace Orabot.EventHandlers.CustomMessageHandlers.NumberParsingMessageHandler
 			{
 				var split = match.Groups.Values.Last().Value.Split('#');
 				var keyword = split[0];
-				var number = int.Parse(split[1]);
-				if (MinimumHandledNumberPerKeyword[keyword] <= number)
+				if (int.TryParse(split[1], out var number) && MinimumHandledNumberPerKeyword[keyword] <= number)
 				{
 					canHandle = true;
 				}


### PR DESCRIPTION
Fixed an oversight in BaseNumberParsingMessageHandler that would lead to throwing exceptions when a channel is mentioned, because the channels are mentioned in the format `<#632295260428566529>`.