### PR TITLE
Fixed an issue with role assignment

### DIFF
--- a/Orabot/App.config
+++ b/Orabot/App.config
@@ -5,7 +5,7 @@
 		<add key="GitHubIconsBaseUrl" value="http://openra.mine.nu/Icons/"/>
 		<add key="OpenRaFaviconUrl" value="http://openra.mine.nu/Icons/OpenRA_favicon.png"/>
 		<add key="TrustedRoles" value="Caretaker;Technical Advisor;Developers"/>
-		<add key="RoleAssignmentMessageId" value=""/>
+		<add key="RoleAssignmentMessageId" value="0"/>
 		<add key="FreelyAssignedRolesByEmote" value="tiberium:Tiberian Dawn; nod:Tiberian Dawn; gdi:TiberianDawn; allies:Red Alert; Atreides:Dune 2000; shaihulud:Dune 2000; Harkonnen:Dune 2000; Ordos:Dune 2000;"/>
 		<add key="FreelyAssignedRoles" value="Viewers"/>
 		<add key="LogStorageFolder" value=""/>


### PR DESCRIPTION
This would cause a crash at startup unless a message ID is specified, so adding a harmless default value.